### PR TITLE
Convert to setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ venv.bak/
 
 # vscode
 .vscode/
+
+#

--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,1 @@
-flasktop
+my-flask-desktop

--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,0 @@
-my-flask-desktop

--- a/examples/test_app.py
+++ b/examples/test_app.py
@@ -8,7 +8,7 @@ ui = WebUI(app, debug=True)
 
 @app.route('/')
 def main():
-  return "Hello world!"
+    return "Hello world!"
 
 if __name__ == '__main__':
-  ui.run()
+    ui.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Jinja2==2.10.0
 Werkzeug==0.14
 MarkupSafe==1.0
 itsdangerous==0.24
-PyQt5==5.8.2
+PyQt5==5.9

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,15 @@ with open('requirements.txt') as f:
     required = f.read().splitlines()
 
 setup(
-	name='WebUI',
-	version='0.2.0',
-	author='Nick Johnstone',
-	author_email='ncwjohnstone@gmail.com',
-	packages=['webui'],
-	scripts=['examples/test_app.py'],
-	url='https://github.com/Widdershin/WebUI/',
-	license='MIT',
-	description='WebUI lets you create first class desktop applications in Python with HTML/CSS',
-	long_description=open('README.md').read(),
-	install_requires=required,
-	)
+    name='WebUI',
+    version='0.2.0',
+    author='Nick Johnstone',
+    author_email='ncwjohnstone@gmail.com',
+    packages=['webui'],
+    scripts=['examples/test_app.py'],
+    url='https://github.com/Widdershin/WebUI/',
+    license='MIT',
+    description='WebUI lets you create first class desktop applications in Python with HTML/CSS',
+    long_description=open('README.md').read(),
+    install_requires=required,
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import *
 
 with open('requirements.txt') as f:
     required = f.read().splitlines()

--- a/webui/webui.py
+++ b/webui/webui.py
@@ -1,4 +1,5 @@
 from threading import Thread
+import time
 
 import PyQt5.QtCore as core
 import PyQt5.QtWidgets as core_widgets
@@ -23,6 +24,7 @@ class WebUI(object):
 
     def run(self):
         self.run_flask()
+        time.sleep(1)
         self.run_gui()
 
     def run_flask(self):


### PR DESCRIPTION
I don't really need to be making pull requests, but I find that it's a good habit to have.

- converted setup.py to use setuptools instead of distutils so that I can finally `pip uninstall flask-desktop` without all that `this is a distutils project so we'd only ever be able to do a partial uninstall` crap
- .python-version snuck its way into the repo somehow so I nuked it
- changed pyqt5 version from 2.8.2. to 2.9 because pip was all like ` Could not find suitable distribution for Requirement.parse('PyQt5==2.8.2)` 